### PR TITLE
fix Fatal error: Call-time pass-by-reference has been removed

### DIFF
--- a/attempt/review.php
+++ b/attempt/review.php
@@ -260,14 +260,14 @@ class mod_taskchain_attempt_review {
                 // add separator
                 if (count($table->data)) {
                     $callback = array($class, 'add_separator'); // PHP 5.2
-                    call_user_func($callback, &$table, $question_colspan);
+                    call_user_func_array($callback, array(&$table, $question_colspan));
                 }
 
                 // question text
                 if (call_user_func(array($class, 'show_question_text'))) {
                     if ($text = mod_taskchain::get_question_text($questions[$response->questionid])) {
                         $callback = array($class, 'add_question_text'); // PHP 5.2
-                        call_user_func($callback, &$table, $text, $question_colspan);
+                        call_user_func_array($callback, array(&$table, $text, $question_colspan));
                     }
                 }
 
@@ -294,19 +294,19 @@ class mod_taskchain_attempt_review {
                         $neutral_text .= ($neutral_text ? ',' : '').$text;
                     } else {
                         $callback = array($class, 'add_text_field'); // PHP 5.2
-                        call_user_func($callback, &$table, $field, $text, $textfield_colspan);
+                        call_user_func_array($callback, array(&$table, $field, $text, $textfield_colspan));
                     }
                 }
                 if ($neutral_text) {
                     $callback = array($class, 'add_text_field'); // PHP 5.2
-                    call_user_func($callback, &$table, 'responses', $neutral_text, $textfield_colspan);
+                    call_user_func_array($callback, array(&$table, 'responses', $neutral_text, $textfield_colspan));
                 }
 
                 // numeric fields
                 $row = new html_table_row();
                 foreach ($response_num_fields as $field) {
                     $callback = array($class, 'add_num_field'); // PHP 5.2
-                    call_user_func($callback, &$row, $field, $response->$field);
+                    call_user_func_array($callback, array(&$row, $field, $response->$field));
                 }
                 $table->data[] = $row;
             }


### PR DESCRIPTION
Hi Gordon,

call_user_func does not accept arguments to be passed by reference anymore.
The trick is to call call_user_func_array instead.

Best regards

Eric
