### PR TITLE
fix: call time pass by reference fatal error

### DIFF
--- a/report/taskanalysis/renderer.php
+++ b/report/taskanalysis/renderer.php
@@ -58,7 +58,7 @@ class mod_taskchain_report_taskanalysis_renderer extends mod_taskchain_report_re
     public function add_responses_to_rawdata(&$table) {
         // attach each response to its parent attempt
         // using the "add_response_to_rawdata()" method
-        parent::add_responses_to_rawdata(&$table);
+        parent::add_responses_to_rawdata($table);
 
         // the fields we are interested in, in the order we want them
         $fields = array('correct', 'wrong', 'ignored', 'hints', 'clues', 'checks'); // , 'weighting'


### PR DESCRIPTION
Fatal error: Call-time pass-by-reference has been removed in
./report/taskanalysis/renderer.php on
line 61

Signed-off-by: Eric Villard dev@eviweb.fr
