### PR TITLE
Remove unused cron config option

### DIFF
--- a/lang/en/taskchain.php
+++ b/lang/en/taskchain.php
@@ -56,7 +56,6 @@ $string['taskchain:view'] = 'View the entry page of a TaskChain activity';
 //
 $string['configbodystyles'] = 'By default, Moodle theme styles will override TaskChain activity styles. However, for any styles selected here, the TaskChain activity styles, including any styles defined in task source files such as Hot Potatoes files, will be given priority over the Moodle theme styles.';
 $string['configenablecache'] = 'Maintaining a cache of TaskChain tasks can dramatically speed up the delivery of tasks to the students.';
-$string['configenablecron'] = 'Specify the hours in your time zone at which the TaskChain cron script may run';
 $string['configenablemymoodle'] = 'This settings controls whether TaskChains are listed on the MyMoodle page or not';
 $string['configenableobfuscate'] = 'Obfuscating the javascript code to insert media players makes it more difficult to determine the media file name and guess what the file contains.';
 $string['configenableswf'] = 'Allow embedding of SWF files in TaskChain activities. If enabled, this setting overrides filter_mediaplugin_enable_swf.';
@@ -448,7 +447,6 @@ $string['editcolumnlistschain'] = 'Edit columns for TaskChain Chains';
 $string['editcolumnliststask'] = 'Edit columns for TaskChain Tasks';
 $string['edittasks'] = 'Edit tasks';
 $string['enablecache'] = 'Enable TaskChain cache';
-$string['enablecron'] = 'Enable TaskChain cron';
 $string['enablemymoodle'] = 'Show TaskChains on MyMoodle';
 $string['enableobfuscate'] = 'Enable obfuscation of media player code';
 $string['enableswf'] = 'Allow embedding of SWF files in TaskChain activities';

--- a/settings.php
+++ b/settings.php
@@ -47,24 +47,6 @@ $settings->add(
     new admin_setting_configcheckbox('taskchain_enablecache', get_string('enablecache', 'mod_taskchain'), get_string('configenablecache', 'mod_taskchain').' '.$link, 1)
 );
 
-/** Prevent direct access to this script */
-defined('MOODLE_INTERNAL') || die();
-
-// restrict cron job to certain hours of the day (default=never)
-$timezone = get_user_timezone_offset();
-if (abs($timezone) > 13) {
-    $timezone = 0;
-} else if ($timezone>0) {
-    $timezone = $timezone - 24;
-}
-$options = array();
-for ($i=0; $i<=23; $i++) {
-    $options[($i - $timezone) % 24] = gmdate('H:i', $i * HOURSECS);
-}
-$settings->add(
-    new admin_setting_configmultiselect('taskchain_enablecron', get_string('enablecron', 'mod_taskchain'), get_string('configenablecron', 'mod_taskchain'), array(), $options)
-);
-
 // enable embedding of swf media objects intaskchain tasks (default=1)
 $settings->add(
     new admin_setting_configcheckbox('taskchain_enableswf', get_string('enableswf', 'mod_taskchain'), get_string('configenableswf', 'mod_taskchain'), 1)
@@ -110,5 +92,5 @@ $setting->set_updatedcallback('taskchain_refresh_events');
 $settings->add($setting);
 
 // dispose of temporary variables used above
-unset($str, $url, $link, $timezone, $options, $i);
+unset($str, $url, $link, $options, $i);
 


### PR DESCRIPTION
This conflicts with Moodle 2.9's timezone changes, and is not used anywhere in the code. If it was ever needed, Moodle tasks would seem more appropriate anyway!

Also, the define was duplicated..