### PR TITLE
backup and restore files in configfile area

### DIFF
--- a/backup/moodle2/backup_taskchain_stepslib.php
+++ b/backup/moodle2/backup_taskchain_stepslib.php
@@ -244,6 +244,7 @@ class backup_taskchain_activity_structure_step extends backup_activity_structure
         ////////////////////////////////////////////////////////////////////////
 
         $taskchain->annotate_files('mod_taskchain', 'sourcefile', null);
+        $taskchain->annotate_files('mod_taskchain', 'configfile', null);
         $taskchain->annotate_files('mod_taskchain', 'entrytext',  null);
         $taskchain->annotate_files('mod_taskchain', 'exittext',   null);
 

--- a/backup/moodle2/restore_taskchain_stepslib.php
+++ b/backup/moodle2/restore_taskchain_stepslib.php
@@ -521,6 +521,7 @@ class restore_taskchain_activity_structure_step extends restore_activity_structu
 
         // restore files
         $this->add_related_files('mod_taskchain', 'sourcefile', null);
+        $this->add_related_files('mod_taskchain', 'configfile', null);
         $this->add_related_files('mod_taskchain', 'entrytext',  null);
         $this->add_related_files('mod_taskchain', 'exittext',   null);
 


### PR DESCRIPTION
The task configuration file is not currently included in backup/restore operations. This change adds the `configfile` filearea to the backup and restore process.